### PR TITLE
chore(ghooks): removes ghooks and adds husky w prepush hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "build": "gulp",
     "lint": "gulp lint",
     "test": "gulp mocha",
-    "commit": "git-cz",
-    "report-coverage": "coveralls < ./coverage/lcov.info"
+    "report-coverage": "coveralls < ./coverage/lcov.info",
+    "prepush": "npm test"
   },
   "repository": {
     "type": "git",
@@ -61,13 +61,11 @@
     "babel-preset-es2015": "6.5.0",
     "babel-preset-stage-2": "6.5.0",
     "chai": "^3.4.1",
-    "commitizen": "^2.8.2",
     "coveralls": "^2.11.6",
     "cz-conventional-changelog": "1.1.5",
     "del": "^2.2.0",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "5.0.1",
-    "ghooks": "^1.2.4",
     "gulp": "3.9.1",
     "gulp-babel": "6.1.2",
     "gulp-env": "^0.4.0",
@@ -80,6 +78,7 @@
     "gulp-plumber": "^1.0.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.7",
+    "husky": "^0.11.8",
     "isparta": "4.0.0",
     "mocha": "2.5.3",
     "run-sequence": "^1.1.5",
@@ -88,15 +87,6 @@
     "validate-commit-msg": "^2.6.1"
   },
   "license": "MIT",
-  "config": {
-    "ghooks": {
-      "pre-commit": "npm run lint && npm test",
-      "commit-msg": "validate-commit-msg"
-    },
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
-    }
-  },
   "babel": {
     "presets": [
       "es2015",


### PR DESCRIPTION
Removes commit hooks and uses husky to provide a single, pre-push hook that makes sure all tests are passing (no more commit time annoyingness!). To clean up your hooks I believe you can remove the hooks files from .git/hooks and run `npm install husky` again - it will install the hooks for you.
