### PR TITLE
Make microservices ready

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -47,7 +47,7 @@ if (config.env === 'development') {
 }
 
 // mount all routes on /api path
-app.use('/api', routes);
+app.use('/', routes);
 
 // if error is not an instanceOf APIError, convert it.
 app.use((err, req, res, next) => {

--- a/index.js
+++ b/index.js
@@ -2,14 +2,20 @@ import Promise from 'bluebird';
 import mongoose from 'mongoose';
 import config from './config/env';
 import app from './config/express';
+import winston from './config/winston';
 
 // promisify mongoose
 Promise.promisifyAll(mongoose);
 
 // connect to mongo db
+winston.log('info', 'starting api service.');
 mongoose.connect(config.db, { server: { socketOptions: { keepAlive: 1 } } });
 mongoose.connection.on('error', () => {
-  throw new Error(`unable to connect to database: ${config.db}`);
+  winston.log('error', `unable to connect to database: ${config.db}`);
+  winston.log('error', 'retrying in 2 seconds.');
+  setTimeout(() => {
+    mongoose.connect(config.db, { server: { socketOptions: { keepAlive: 1 } } });
+  }, 2000);
 });
 
 const debug = require('debug')('express-mongoose-es6-rest-api:index');


### PR DESCRIPTION
A few things are going on here. First of all, I moved the root for all routes to `/`, with the thinking that we can use LBaaS to map this service onto a coherent URL structure; we don't need to hard-wire that buried in our boilerplate. Second, I set up the app so that if Mongo is not ready or goes down for some reason, we should continuously retry it; the Kubernetes replication controller will be restarting Mongo, so we should rely on that.

In the future we may want to set the retry timeout to be configurable on an environment variable, but for now, I hardwired it to two seconds because that is sane.
