### PR TITLE
add-auth0-jwt-check-all-endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cors": "^2.7.1",
     "debug": "^2.2.0",
     "express": "4.14.0",
-    "express-jwt": "3.4.0",
+    "express-jwt": "^3.4.0",
     "express-validation": "1.0.0",
     "express-winston": "^1.2.0",
     "helmet": "2.1.1",

--- a/src/config/env/development.js
+++ b/src/config/env/development.js
@@ -1,6 +1,7 @@
 export default {
-  env: 'development',
-  jwtSecret: '0a6b944d-d2fb-46fc-a85e-0295c986cd9f',
-  db: 'mongodb://localhost/express-mongoose-es6-rest-api-development',
-  port: 3000
+  env: process.env.NODE_ENV,
+  jwtSecret: process.env.JWT_SECRET,
+  jwtAudience: process.env.JWT_AUDIENCE,
+  db: process.env.DB,
+  port: process.env.PORT
 };

--- a/src/config/env/docker.js
+++ b/src/config/env/docker.js
@@ -1,6 +1,7 @@
 export default {
   env: process.env.NODE_ENV,
   jwtSecret: process.env.JWT_SECRET,
+  jwtAudience: process.env.JWT_AUDIENCE,
   db: process.env.DB,
   port: process.env.PORT
 };

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -3,10 +3,20 @@ import userRoutes from './user';
 import authRoutes from './auth';
 import flightRosterRoutes from './flights';
 import flightRoutes from './flight';
+import config from '../../config/env';
+const jwt = require('express-jwt');
+
+const jwtCheck = jwt({
+  secret: new Buffer(config.jwtSecret, 'base64'),
+  audience: config.jwtAudience
+});
 
 const router = express.Router();	// eslint-disable-line new-cap
 
 /** GET /health-check - Check service health */
+
+router.use(jwtCheck);
+
 router.get('/health-check', (req, res) =>
   res.send('OK')
 );

--- a/src/server/tests/unit/telemetry.controller.test.js
+++ b/src/server/tests/unit/telemetry.controller.test.js
@@ -1,21 +1,15 @@
 import assert from 'assert';
 const Telemetry = require('../../models/telemetry');
 const sinon = require('sinon');
-// require('sinon-mongoose');
 require('sinon-as-promised');
 const telemetryData = require('gomake-mock-data');
 const TelemetryController = require('../../controllers/telemetry');
 
 describe('Telemetry', () => {
-  /*
-    const Model = sinon.mock(Telemetry);
-    const args = {arg1: val1};
-    Model.expects('findOne').withArgs(findByArgs).resovles('ResolveValue');
-   */
   describe('model', () => {
     it('should return telemetry data', (done) => {
       const TelemetryMock = sinon.mock(Telemetry);
-      const mockTelemetryItem = telemetryData.get('telemetry', 'telemetry', 1)[0];
+      const mockTelemetryItem = telemetryData.get('telemetry', 'goodTelemetry', 1)[0];
       TelemetryMock.expects('findOne').withArgs().resolves(mockTelemetryItem);
       Telemetry.findOne().then((res) => {
         TelemetryMock.verify();
@@ -49,7 +43,7 @@ describe('Telemetry', () => {
     });
 
     it('should return single telemetry object', (done) => {
-      const mockTelemetryItem = telemetryData.get('telemetry', 'telemetry', 1);
+      const mockTelemetryItem = telemetryData.get('telemetry', 'goodTelemetry', 1);
       sinon.stub(Telemetry, 'findOne').returns({
         then: () => {
           return mockTelemetryItem;


### PR DESCRIPTION
@jonathanbarton  This ensures all our endpoints have the bearer token.

I need to add the logic to handle requests that do not require jwt. (Maybe an array of endpoints  to exclude).
I still need to figure out rules and login stuff though.
