### PR TITLE
return 200 rather than 403 for Google Cloud health check purposes

### DIFF
--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -15,7 +15,7 @@ const router = express.Router();	// eslint-disable-line new-cap
 // router.use(jwtCheck);
 
 router.get('/', (req, res) => {
-  res.sendStatus(403);
+  res.sendStatus(200);
 });
 
 router.get('/health-check', (req, res) => {


### PR DESCRIPTION
Google Cloud looks (at least by default) on `/` to do a health check / keepalive. We were 403ing it before, which I think was causing Google HC to hammer it.