### PR TITLE
fixes history endpoint

### DIFF
--- a/src/server/controllers/history.js
+++ b/src/server/controllers/history.js
@@ -7,23 +7,27 @@ const TELEMETRY_ERROR = 400;
 function getFlightHistory(req, res) {
   const flightName = req.params.flightname.toUpperCase();
   const getFlight = Flight.getFlightFromFlightName(flightName);
+  const startTransmitTime = req.query.start;
   getFlight
-    .then(getHistoryForAssignedDevices, sendFailureResponse(res))
+    .then(getHistoryForAssignedDevices(startTransmitTime), sendFailureResponse(res))
     .then(sendSuccessResponse(res), sendFailureResponse(res));
 }
 
-function getHistoryForAssignedDevices(foundFlight) {
-  const devices = foundFlight.deviceIds;
-  return Telemetry.find({ deviceId: { $in: devices } })
-    .sort('-transmitTime');
+function getHistoryForAssignedDevices(startTransmitTime) {
+  return (foundFlight) => {
+    const devices = foundFlight.deviceIds;
+    const startTimeAsDate = new Date(startTransmitTime);
+    return Telemetry.find({ deviceId: { $in: devices }, transmitTime: { $gte: startTimeAsDate } })
+      .sort('-transmitTime');
+  };
 }
 
 function sendFailureResponse(res) {
-  return (telemetry) => { res.json(contentResponse(telemetry)); };
+  return () => { res.sendStatus(TELEMETRY_ERROR); };
 }
 
 function sendSuccessResponse(res) {
-  return () => { res.sendStatus(TELEMETRY_ERROR); };
+  return (telemetry) => { res.json(contentResponse(telemetry)); };
 }
 
 export default {


### PR DESCRIPTION
swaps the responses (woops), adds a start date parameter to the query string to limit the return to the last known telemetry location until now