### PR TITLE
add an unstable tag to the latest build, which we can promote to latest after integration tests run

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,3 +28,4 @@ deployment:
       - gcloud --quiet components update app
       - gcloud auth activate-service-account --key-file ${HOME}/client-secret.json
       - gcloud docker -- push gcr.io/${GCLOUD_PROJECT}/api:${CIRCLE_BUILD_NUM}
+      - gcloud container images add-tag gcr.io/${GCLOUD_PROJECT}/api:${CIRCLE_BUILD_NUM} gcr.io/${GCLOUD_PROJECT}/api:unstable


### PR DESCRIPTION
With an updated version of `gcloud`, I discovered it is possible to add additional tags to an image residing in Google Container Registry. As such, I am modifying our `circle.yml` file to add the `unstable` tag to the latest successfully built image.

We can then run our integration tests against the `unstable` image, and promote it to `latest` if the tests pass.

cc: @jonathanbarton @nehaabrol87 