### PR TITLE
switch to node-alpine distribution to cut image size in half

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.4.0-wheezy
+FROM node:7.9.0-alpine
 
 # Create app directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
We can benefit from using Alpine linux as the base for our image rather than Debian because it is a lot smaller and provides the same feature set. 

cc: @jonathanbarton @nehaabrol87 