### PR TITLE
put-delete-take-userid-from-path-not-token

### DIFF
--- a/src/server/controllers/flight.js
+++ b/src/server/controllers/flight.js
@@ -1,7 +1,6 @@
 import Flight from '../models/flight';
 import mongoErrorCodes from '../models/mongoErrorCodes';
 
-const NO_VALID_USERID_ERROR = 'No valid user Id present';
 const NO_VALID_FLIGHT_ERROR = 'No valid flight present';
 const MISSING_REQUIRED_PARAMS = 'Missing required parameters';
 const DUPLICATE_VALUE = 'Duplicate value';
@@ -76,10 +75,7 @@ function isValidGeoJson(location) {
 }
 
 function putUserInFlight(req, res) {
-  const userId = getUserId(req.user);
-  if (!userId) {
-    return res.badRequest(res, NO_VALID_USERID_ERROR);
-  }
+  const userId = getUserId(req);
   const dbUpdateConfig = {
     $addToSet: {
       userIds: userId
@@ -89,10 +85,7 @@ function putUserInFlight(req, res) {
 }
 
 function deleteUserInFlight(req, res) {
-  const userId = getUserId(req.user, res);
-  if (!userId) {
-    return res.badRequest(res, NO_VALID_USERID_ERROR);
-  }
+  const userId = getUserId(req);
   const dbUpdateConfig = {
     $pull: {
       userIds: userId
@@ -121,8 +114,8 @@ function updateFlightUsers(req, res, dbUpdateConfig) {
     });
 }
 
-function getUserId(user) {
-  const userId = user.user_id;
+function getUserId(req) {
+  const userId = req.params.userid;
   return userId;
 }
 

--- a/src/server/tests/unit/controllers/flight.unit.test.js
+++ b/src/server/tests/unit/controllers/flight.unit.test.js
@@ -124,13 +124,6 @@ describe('Flight', () => {
           done();
         });
     });
-
-    it('should return badRequest if no user id is present', (done) => {
-      req.user = {};
-      FlightController.putUserInFlight(req, res);
-      assert(resBadRequestSpy.calledWith(res, 'No valid user Id present'));
-      done();
-    });
   });
 
   describe('#DeleteUserInFlight', () => {
@@ -156,12 +149,6 @@ describe('Flight', () => {
           Flight.findOneAndUpdate.restore();
           done();
         });
-    });
-    it('should return bad request if no user id is present', (done) => {
-      req.user = {};
-      FlightController.deleteUserInFlight(req, res);
-      assert(resBadRequestSpy.calledWith(res, 'No valid user Id present'));
-      done();
     });
   });
 });


### PR DESCRIPTION
@jonathanbarton This takes care of the bug where the user id for PUT and DELETE endpoints was being picked from token and not path.
I will fix the JOI pattern error responses in a separate PR.
As of now we return the stack trace.
Will add some logic to return elegant messages.
🦅  👁 