### PR TITLE
filter-0-&-null-history-telemetry

### DIFF
--- a/src/server/controllers/history.js
+++ b/src/server/controllers/history.js
@@ -20,6 +20,7 @@ function getHistoryForAssignedDevices(startTransmitTime) {
     const startTimeAsDate = getStartTimeAsDate(startTransmitTime);
     return Telemetry.find({
       deviceId: { $in: devices },
+      'location.coordinates': { $nin: [null, 0.0] },
       transmitTime: { $gte: startTimeAsDate }
     }).sort('-transmitTime');
   };

--- a/src/server/controllers/telemetry.js
+++ b/src/server/controllers/telemetry.js
@@ -24,7 +24,7 @@ function getTelemetry(req, res) {
 function getTelemetryForAssignedDevices(foundFlight) {
   const devices = foundFlight.deviceIds;
   return Telemetry
-    .find({ deviceId: { $in: devices } })
+    .find({ deviceId: { $in: devices }, 'location.coordinates': { $nin: [null, 0.0] } })
     .sort({ $natural: -1 })
     .limit(1);
 }


### PR DESCRIPTION
@jonathanbarton 
This excludes null and 0.0 co ordinates in endpoint response (GET telemetry and GET history)

cc @tgb20  Post this if you see any 0.0 or null coords please report back to me.